### PR TITLE
adding height to submission process

### DIFF
--- a/build/js/src/eme/solicits/command/ImportSubmissionV1.js
+++ b/build/js/src/eme/solicits/command/ImportSubmissionV1.js
@@ -59,6 +59,12 @@ export default class ImportSubmissionV1 extends Message {
         Fb.create('age', T.TinyIntType.create())
           .max(120)
           .build(),
+        /*
+         * The person's physical height recorded in inches.
+         */
+        Fb.create('height', T.TinyIntType.create())
+          .max(120)
+          .build(),
         Fb.create('gender', T.IntEnumType.create())
           .classProto(Gender)
           .build(),

--- a/build/js/src/eme/solicits/command/SendSubmissionV1.js
+++ b/build/js/src/eme/solicits/command/SendSubmissionV1.js
@@ -63,6 +63,12 @@ export default class SendSubmissionV1 extends Message {
         Fb.create('age', T.TinyIntType.create())
           .max(120)
           .build(),
+        /*
+         * The person's physical height recorded in inches.
+         */
+        Fb.create('height', T.TinyIntType.create())
+          .max(120)
+          .build(),
         Fb.create('gender', T.IntEnumType.create())
           .classProto(Gender)
           .build(),

--- a/build/js/src/eme/solicits/event/SubmissionReceivedV1.js
+++ b/build/js/src/eme/solicits/event/SubmissionReceivedV1.js
@@ -67,6 +67,12 @@ export default class SubmissionReceivedV1 extends Message {
         Fb.create('age', T.TinyIntType.create())
           .max(120)
           .build(),
+        /*
+         * The person's physical height recorded in inches.
+         */
+        Fb.create('height', T.TinyIntType.create())
+          .max(120)
+          .build(),
         Fb.create('gender', T.IntEnumType.create())
           .withDefault(Gender.UNKNOWN)
           .classProto(Gender)

--- a/build/js/src/eme/solicits/request/SearchSubmissionsRequestV1.js
+++ b/build/js/src/eme/solicits/request/SearchSubmissionsRequestV1.js
@@ -45,6 +45,12 @@ export default class SearchSubmissionsRequestV1 extends Message {
         Fb.create('age_max', T.TinyIntType.create())
           .max(120)
           .build(),
+        Fb.create('height_min', T.TinyIntType.create())
+          .max(120)
+          .build(),
+        Fb.create('height_max', T.TinyIntType.create())
+          .max(120)
+          .build(),
         Fb.create('has_notes', T.TrinaryType.create())
           .build(),
         Fb.create('is_blocked', T.TrinaryType.create())

--- a/build/php/src/Eme/Schemas/Solicits/Command/ImportSubmissionV1.php
+++ b/build/php/src/Eme/Schemas/Solicits/Command/ImportSubmissionV1.php
@@ -79,6 +79,12 @@ final class ImportSubmissionV1 extends AbstractMessage implements
                 Fb::create('age', T\TinyIntType::create())
                     ->max(120)
                     ->build(),
+                /*
+                 * The person's physical height recorded in inches.
+                 */
+                Fb::create('height', T\TinyIntType::create())
+                    ->max(120)
+                    ->build(),
                 Fb::create('gender', T\IntEnumType::create())
                     ->className(Gender::class)
                     ->build(),

--- a/build/php/src/Eme/Schemas/Solicits/Command/SendSubmissionV1.php
+++ b/build/php/src/Eme/Schemas/Solicits/Command/SendSubmissionV1.php
@@ -83,6 +83,12 @@ final class SendSubmissionV1 extends AbstractMessage implements
                 Fb::create('age', T\TinyIntType::create())
                     ->max(120)
                     ->build(),
+                /*
+                 * The person's physical height recorded in inches.
+                 */
+                Fb::create('height', T\TinyIntType::create())
+                    ->max(120)
+                    ->build(),
                 Fb::create('gender', T\IntEnumType::create())
                     ->className(Gender::class)
                     ->build(),

--- a/build/php/src/Eme/Schemas/Solicits/Event/SubmissionReceivedV1.php
+++ b/build/php/src/Eme/Schemas/Solicits/Event/SubmissionReceivedV1.php
@@ -95,6 +95,12 @@ final class SubmissionReceivedV1 extends AbstractMessage implements
                 Fb::create('age', T\TinyIntType::create())
                     ->max(120)
                     ->build(),
+                /*
+                 * The person's physical height recorded in inches.
+                 */
+                Fb::create('height', T\TinyIntType::create())
+                    ->max(120)
+                    ->build(),
                 Fb::create('gender', T\IntEnumType::create())
                     ->withDefault(Gender::UNKNOWN())
                     ->className(Gender::class)

--- a/build/php/src/Eme/Schemas/Solicits/Request/SearchSubmissionsRequestV1.php
+++ b/build/php/src/Eme/Schemas/Solicits/Request/SearchSubmissionsRequestV1.php
@@ -59,6 +59,12 @@ final class SearchSubmissionsRequestV1 extends AbstractMessage implements
                 Fb::create('age_max', T\TinyIntType::create())
                     ->max(120)
                     ->build(),
+                Fb::create('height_min', T\TinyIntType::create())
+                    ->max(120)
+                    ->build(),
+                Fb::create('height_max', T\TinyIntType::create())
+                    ->max(120)
+                    ->build(),
                 Fb::create('has_notes', T\TrinaryType::create())
                     ->build(),
                 Fb::create('is_blocked', T\TrinaryType::create())

--- a/gh-pages/json-schema/eme/solicits/command/import-submission/1-0-0.json
+++ b/gh-pages/json-schema/eme/solicits/command/import-submission/1-0-0.json
@@ -450,6 +450,17 @@
         "rule": "single"
       }
     },
+    "height": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 120,
+      "description": "The person's physical height recorded in inches.",
+      "pbj": {
+        "type": "tiny-int",
+        "rule": "single"
+      }
+    },
     "gender": {
       "type": "integer",
       "enum": [

--- a/gh-pages/json-schema/eme/solicits/command/import-submission/latest.json
+++ b/gh-pages/json-schema/eme/solicits/command/import-submission/latest.json
@@ -450,6 +450,17 @@
         "rule": "single"
       }
     },
+    "height": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 120,
+      "description": "The person's physical height recorded in inches.",
+      "pbj": {
+        "type": "tiny-int",
+        "rule": "single"
+      }
+    },
     "gender": {
       "type": "integer",
       "enum": [

--- a/gh-pages/json-schema/eme/solicits/command/send-submission/1-0-0.json
+++ b/gh-pages/json-schema/eme/solicits/command/send-submission/1-0-0.json
@@ -451,6 +451,17 @@
         "rule": "single"
       }
     },
+    "height": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 120,
+      "description": "The person's physical height recorded in inches.",
+      "pbj": {
+        "type": "tiny-int",
+        "rule": "single"
+      }
+    },
     "gender": {
       "type": "integer",
       "enum": [

--- a/gh-pages/json-schema/eme/solicits/command/send-submission/latest.json
+++ b/gh-pages/json-schema/eme/solicits/command/send-submission/latest.json
@@ -451,6 +451,17 @@
         "rule": "single"
       }
     },
+    "height": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 120,
+      "description": "The person's physical height recorded in inches.",
+      "pbj": {
+        "type": "tiny-int",
+        "rule": "single"
+      }
+    },
     "gender": {
       "type": "integer",
       "enum": [

--- a/gh-pages/json-schema/eme/solicits/event/submission-received/1-0-0.json
+++ b/gh-pages/json-schema/eme/solicits/event/submission-received/1-0-0.json
@@ -455,6 +455,17 @@
         "rule": "single"
       }
     },
+    "height": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 120,
+      "description": "The person's physical height recorded in inches.",
+      "pbj": {
+        "type": "tiny-int",
+        "rule": "single"
+      }
+    },
     "gender": {
       "type": "integer",
       "default": 0,

--- a/gh-pages/json-schema/eme/solicits/event/submission-received/latest.json
+++ b/gh-pages/json-schema/eme/solicits/event/submission-received/latest.json
@@ -455,6 +455,17 @@
         "rule": "single"
       }
     },
+    "height": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 120,
+      "description": "The person's physical height recorded in inches.",
+      "pbj": {
+        "type": "tiny-int",
+        "rule": "single"
+      }
+    },
     "gender": {
       "type": "integer",
       "default": 0,

--- a/gh-pages/json-schema/eme/solicits/request/search-submissions-request/1-0-0.json
+++ b/gh-pages/json-schema/eme/solicits/request/search-submissions-request/1-0-0.json
@@ -357,6 +357,26 @@
         "rule": "single"
       }
     },
+    "height_min": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 120,
+      "pbj": {
+        "type": "tiny-int",
+        "rule": "single"
+      }
+    },
+    "height_max": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 120,
+      "pbj": {
+        "type": "tiny-int",
+        "rule": "single"
+      }
+    },
     "has_notes": {
       "type": "integer",
       "default": 0,

--- a/gh-pages/json-schema/eme/solicits/request/search-submissions-request/latest.json
+++ b/gh-pages/json-schema/eme/solicits/request/search-submissions-request/latest.json
@@ -357,6 +357,26 @@
         "rule": "single"
       }
     },
+    "height_min": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 120,
+      "pbj": {
+        "type": "tiny-int",
+        "rule": "single"
+      }
+    },
+    "height_max": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 120,
+      "pbj": {
+        "type": "tiny-int",
+        "rule": "single"
+      }
+    },
     "has_notes": {
       "type": "integer",
       "default": 0,

--- a/schemas/eme/solicits/command/import-submission/1-0-0.xml
+++ b/schemas/eme/solicits/command/import-submission/1-0-0.xml
@@ -32,6 +32,9 @@
       </field>
       <field name="dob" type="date"/>
       <field name="age" type="tiny-int" max="120"/>
+      <field name="height" type="tiny-int" max="120">
+        <description>The person's physical height recorded in inches.</description>
+      </field>
       <field name="gender" type="int-enum">
         <enum id="gdbots:common:gender"/>
       </field>

--- a/schemas/eme/solicits/command/import-submission/latest.xml
+++ b/schemas/eme/solicits/command/import-submission/latest.xml
@@ -32,6 +32,9 @@
       </field>
       <field name="dob" type="date"/>
       <field name="age" type="tiny-int" max="120"/>
+      <field name="height" type="tiny-int" max="120">
+        <description>The person's physical height recorded in inches.</description>
+      </field>
       <field name="gender" type="int-enum">
         <enum id="gdbots:common:gender"/>
       </field>

--- a/schemas/eme/solicits/command/send-submission/1-0-0.xml
+++ b/schemas/eme/solicits/command/send-submission/1-0-0.xml
@@ -37,6 +37,9 @@
           "dob" and "occurred_at" to determine the age at the time of the response.
         </description>
       </field>
+      <field name="height" type="tiny-int" max="120">
+        <description>The person's physical height recorded in inches.</description>
+      </field>
       <field name="gender" type="int-enum">
         <enum id="gdbots:common:gender"/>
       </field>

--- a/schemas/eme/solicits/command/send-submission/latest.xml
+++ b/schemas/eme/solicits/command/send-submission/latest.xml
@@ -37,6 +37,9 @@
           "dob" and "occurred_at" to determine the age at the time of the response.
         </description>
       </field>
+      <field name="height" type="tiny-int" max="120">
+        <description>The person's physical height recorded in inches.</description>
+      </field>
       <field name="gender" type="int-enum">
         <enum id="gdbots:common:gender"/>
       </field>

--- a/schemas/eme/solicits/event/submission-received/1-0-0.xml
+++ b/schemas/eme/solicits/event/submission-received/1-0-0.xml
@@ -37,6 +37,9 @@
           "dob" and "occurred_at" to determine the age at the time of the submission.
         </description>
       </field>
+      <field name="height" type="tiny-int" max="120">
+        <description>The person's physical height recorded in inches.</description>
+      </field>
       <field name="gender" type="int-enum">
         <default>0</default>
         <enum id="gdbots:common:gender"/>

--- a/schemas/eme/solicits/event/submission-received/latest.xml
+++ b/schemas/eme/solicits/event/submission-received/latest.xml
@@ -37,6 +37,9 @@
           "dob" and "occurred_at" to determine the age at the time of the submission.
         </description>
       </field>
+      <field name="height" type="tiny-int" max="120">
+        <description>The person's physical height recorded in inches.</description>
+      </field>
       <field name="gender" type="int-enum">
         <default>0</default>
         <enum id="gdbots:common:gender"/>

--- a/schemas/eme/solicits/request/search-submissions-request/1-0-0.xml
+++ b/schemas/eme/solicits/request/search-submissions-request/1-0-0.xml
@@ -26,6 +26,8 @@
       </field>
       <field name="age_min" type="tiny-int" max="120"/>
       <field name="age_max" type="tiny-int" max="120"/>
+      <field name="height_min" type="tiny-int" max="120"/>
+      <field name="height_max" type="tiny-int" max="120"/>
       <field name="has_notes" type="trinary"/>
       <field name="is_blocked" type="trinary"/>
       <field name="is_read" type="trinary"/>

--- a/schemas/eme/solicits/request/search-submissions-request/latest.xml
+++ b/schemas/eme/solicits/request/search-submissions-request/latest.xml
@@ -26,6 +26,8 @@
       </field>
       <field name="age_min" type="tiny-int" max="120"/>
       <field name="age_max" type="tiny-int" max="120"/>
+      <field name="height_min" type="tiny-int" max="120"/>
+      <field name="height_max" type="tiny-int" max="120"/>
       <field name="has_notes" type="trinary"/>
       <field name="is_blocked" type="trinary"/>
       <field name="is_read" type="trinary"/>


### PR DESCRIPTION
When we start the firstdates process we'll need to record "height" (inches) of the person.  This is being implemented as a standard field because it can be used for various shows and it makes the user searching easier to implement as a standard field.  height_min/height_max to search submissions request.